### PR TITLE
after serialport v8 portInfo interface changed comName to path

### DIFF
--- a/public/electron/serialPort.js
+++ b/public/electron/serialPort.js
@@ -46,7 +46,7 @@ async function getPort(comVendorName, productId) {
 
   const device = getDevice(portList, comVendorName, productId);
   try {
-    const path = device[0].comName;
+    const path = device[0].path;
     const port = new SerialPort(path);
     return port;
   } catch {


### PR DESCRIPTION
# Fix getPort to use correct device field (path instead of comName)

This PR updates the getPort function to reference the correct property on the SerialPort.list() result. Previously, the code used device[0].comName, which is not a valid field in serialport v12.x.x. The correct field to use is device[0].path, as defined in the PortInfo interface in the [serialport docs](https://serialport.io/docs/api-bindings-cpp#list).  This field was changed after serialport v8.x.x.x.

This fixes a bug where getPort could silently fail to create a SerialPort due to referencing `comName` rather than `path`. 