### PR TITLE
path args to SerialPort needs to be an object after v10

### DIFF
--- a/public/electron/serialPort.js
+++ b/public/electron/serialPort.js
@@ -15,7 +15,7 @@ function getDevice(portList, comVendorName, productId) {
     const comName = comVendorName;
     return portList.filter(
       // Find the device with the matching comName
-      (device) => device.comName === comName.toUpperCase() || device.comName === comName
+      (device) => device.path === comName.toUpperCase() || device.path === comName
     );
   } else {
     const vendorId = comVendorName;
@@ -47,7 +47,7 @@ async function getPort(comVendorName, productId) {
   const device = getDevice(portList, comVendorName, productId);
   try {
     const path = device[0].path;
-    const port = new SerialPort(path);
+    const port = new SerialPort({path: path});
     return port;
   } catch {
     return false;


### PR DESCRIPTION
### Interface to Create SerialPort is `new SerialPort({path: path})` 

I also resolved an instance of using the deprecated `port.comName` to `port.path`.
 
See Docs: https://serialport.io/docs/guide-usage
Closes #551 